### PR TITLE
M9: refine Hyper-V VM creation and stop handling

### DIFF
--- a/docs/CHECKLIST.md
+++ b/docs/CHECKLIST.md
@@ -67,6 +67,7 @@
 ## M9 — Utilities Polish
 - [~] Ensure `Start/Stop/Checkpoint-RiDVM` use `ShouldProcess` (`-WhatIf/-Confirm`) and show clear errors; add smoke tests.
   - Cmdlets now use `ShouldProcess` and validate VMX with helpful guidance; smoke tests still pending.
+  - [x] Fixed Hyper-V stop logic to use `-Shutdown`/`-TurnOff` appropriately.
 - **How to test:** Use `-WhatIf` to preview and `-Confirm` to run for a known VM; verify outcomes and messages.
 
 ## M10 — Menu Wiring for Full Flows

--- a/src/Public/New-RiDVM.ps1
+++ b/src/Public/New-RiDVM.ps1
@@ -89,7 +89,7 @@ function New-RiDVM {
         if (-not $IsoPath) { $IsoPath = _PromptForIsoIfMissing $IsoPath }
         $vhdPath = Join-Path -Path $DestinationPath -ChildPath ("{0}.vhdx" -f $Name)
         $apply = $PSCmdlet.ShouldProcess($Name, 'Create Hyper-V VM')
-        New-RiDHvVM -Name $Name -MemoryGB ([int]([math]::Ceiling($MemoryMB/1024.0))) -CpuCount $CpuCount -Generation 2 -VhdPath $vhdPath -DiskGB $DiskGB -IsoPath $IsoPath -SwitchName $SwitchName -WhatIf:(!$apply) | Out-Null
+        New-RiDHvVM -Name $Name -MemoryGB ([int]([math]::Ceiling($MemoryMB/1024.0))) -CpuCount $CpuCount -Generation 2 -VhdPath $vhdPath -DiskGB $DiskGB -IsoPath $IsoPath -SwitchName $SwitchName -Path $DestinationPath -WhatIf:(!$apply) | Out-Null
         if ($apply) {
             try { Register-RiDVM -Name $Name -Provider hyperv | Out-Null } catch { Write-Verbose $_ }
             Write-Host 'Hyper-V VM created. You can start it via Start-RiDVM -Name ...' -ForegroundColor Yellow


### PR DESCRIPTION
## Summary
- allow Hyper-V VM creation to specify custom storage path and validate switch
- fix Hyper-V stop helper to use Shutdown for soft and TurnOff for hard stops
- cover Hyper-V routing and stop behaviours with Pester tests

## Testing
- `pwsh -NoLogo -Command "Invoke-ScriptAnalyzer -Path src -Recurse -Severity Warning"` *(fails: command not found)*
- `pwsh -NoLogo -Command "Invoke-Pester -Path tests/unit -PassThru"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ab1c0dc9c4832e91e7b40d8fbb5cf6